### PR TITLE
播放器view销毁时，avplayerItem移除观察

### DIFF
--- a/KNPhotoBrowser/KNPhotoBrowser/KNPhotoAVPlayer/KNPhotoAVPlayerView.m
+++ b/KNPhotoBrowser/KNPhotoBrowser/KNPhotoAVPlayer/KNPhotoAVPlayerView.m
@@ -391,6 +391,7 @@
 }
 
 - (void)dealloc{
+    [self playerWillReset];
     [self removeObserverAndAudioSesstion];
     if (_player && self.timeObserver) {
         [_player removeTimeObserver:self.timeObserver];

--- a/KNPhotoBrowser/KNPhotoBrowser/KNPhotoAVPlayer/KNPhotoLocateAVPlayerView.m
+++ b/KNPhotoBrowser/KNPhotoBrowser/KNPhotoAVPlayer/KNPhotoLocateAVPlayerView.m
@@ -471,6 +471,7 @@
 }
 
 - (void)dealloc{
+    [self playerWillReset];
     [self removeObserverAndAudioSesstion];
     if (_player && self.timeObserver) {
         [_player removeTimeObserver:self.timeObserver];


### PR DESCRIPTION
播放器view销毁时，avplayerItem移除观察，否则多次通过后退按钮退出图片浏览器会闪退